### PR TITLE
auto_route パッケージを導入

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,7 @@ analytics_debug_view_end:
 melos_setup:
 	melos clean
 	melos bootstrap
+
+.PHONY: generate
+generate:
+	melos gen

--- a/melos.yaml
+++ b/melos.yaml
@@ -21,7 +21,9 @@ command:
       flutter_riverpod: ^2.4.3
 
       # Static analysis.
+      custom_lint: ^0.6.4
       pedantic_mono: ^1.27.0
+      riverpod_lint: ^2.3.7
     
     dev_dependencies:
       # Static analysis.

--- a/packages/app/lib/core/router/app_router.dart
+++ b/packages/app/lib/core/router/app_router.dart
@@ -1,0 +1,26 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../ui/page/enter_end_season_page.dart';
+import '../../ui/page/enter_game_stats_page.dart';
+import '../../ui/page/enter_profile_page.dart';
+import '../../ui/page/play_top_page.dart';
+import '../../ui/page/top_page.dart';
+
+part 'app_router.g.dart';
+part 'app_router.gr.dart';
+
+@riverpod
+Raw<AppRouter> appRouter(AppRouterRef ref) => AppRouter();
+
+@AutoRouterConfig(replaceInRouteName: 'Page,Route')
+class AppRouter extends _$AppRouter {
+  @override
+  List<AutoRoute> get routes => [
+        AutoRoute(page: TopRoute.page, initial: true),
+        AutoRoute(page: PlayTopRoute.page),
+        AutoRoute(page: EnterProfileRoute.page),
+        AutoRoute(page: EnterGameStatsRoute.page),
+        AutoRoute(page: EnterEndSeasonRoute.page),
+      ];
+}

--- a/packages/app/lib/core/router/app_router.g.dart
+++ b/packages/app/lib/core/router/app_router.g.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'app_router.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$appRouterHash() => r'd816e70a2ecf0857b88beedbbaa7e3a1b2ba090e';
+
+/// See also [appRouter].
+@ProviderFor(appRouter)
+final appRouterProvider = AutoDisposeProvider<Raw<AppRouter>>.internal(
+  appRouter,
+  name: r'appRouterProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$appRouterHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef AppRouterRef = AutoDisposeProviderRef<Raw<AppRouter>>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/packages/app/lib/core/router/app_router.gr.dart
+++ b/packages/app/lib/core/router/app_router.gr.dart
@@ -1,0 +1,119 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// AutoRouterGenerator
+// **************************************************************************
+
+// ignore_for_file: type=lint
+// coverage:ignore-file
+
+part of 'app_router.dart';
+
+abstract class _$AppRouter extends RootStackRouter {
+  // ignore: unused_element
+  _$AppRouter({super.navigatorKey});
+
+  @override
+  final Map<String, PageFactory> pagesMap = {
+    EnterEndSeasonRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const EnterEndSeasonPage(),
+      );
+    },
+    EnterGameStatsRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const EnterGameStatsPage(),
+      );
+    },
+    EnterProfileRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const EnterProfilePage(),
+      );
+    },
+    PlayTopRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const PlayTopPage(),
+      );
+    },
+    TopRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const TopPage(),
+      );
+    },
+  };
+}
+
+/// generated route for
+/// [EnterEndSeasonPage]
+class EnterEndSeasonRoute extends PageRouteInfo<void> {
+  const EnterEndSeasonRoute({List<PageRouteInfo>? children})
+      : super(
+          EnterEndSeasonRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'EnterEndSeasonRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [EnterGameStatsPage]
+class EnterGameStatsRoute extends PageRouteInfo<void> {
+  const EnterGameStatsRoute({List<PageRouteInfo>? children})
+      : super(
+          EnterGameStatsRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'EnterGameStatsRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [EnterProfilePage]
+class EnterProfileRoute extends PageRouteInfo<void> {
+  const EnterProfileRoute({List<PageRouteInfo>? children})
+      : super(
+          EnterProfileRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'EnterProfileRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [PlayTopPage]
+class PlayTopRoute extends PageRouteInfo<void> {
+  const PlayTopRoute({List<PageRouteInfo>? children})
+      : super(
+          PlayTopRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'PlayTopRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [TopPage]
+class TopRoute extends PageRouteInfo<void> {
+  const TopRoute({List<PageRouteInfo>? children})
+      : super(
+          TopRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'TopRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}

--- a/packages/app/lib/main.dart
+++ b/packages/app/lib/main.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'ui/page/top_page.dart';
+import 'core/router/app_router.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -24,20 +24,16 @@ Future<void> main() async {
   });
 }
 
-class MainApp extends StatelessWidget {
+class MainApp extends ConsumerWidget {
   const MainApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
+  Widget build(BuildContext context, WidgetRef ref) {
+    return MaterialApp.router(
       themeMode: ThemeMode.light,
+      routerConfig: ref.watch(appRouterProvider).config(),
       theme: ThemeData(
         fontFamily: 'MochiyPopOne',
-      ),
-      home: const Scaffold(
-        body: Center(
-          child: TopPage(),
-        ),
       ),
     );
   }

--- a/packages/app/lib/ui/page/enter_end_season_page.dart
+++ b/packages/app/lib/ui/page/enter_end_season_page.dart
@@ -1,19 +1,9 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 
 import 'play_top_page.dart';
 
-// - 各成績のリーグ内順位
-//     - TOP3の場合入力させる
-// - 獲得タイトル
-// - チームのリーグ順位
-// - チームのポストシーズン成績
-// - 来シーズンの年俸
-// - 能力の更新
-// - 背番号の更新
-// - 移籍するかどうか
-//     - 移籍種類
-//     - 移籍先リーグ、チーム
-
+@RoutePage()
 class EnterEndSeasonPage extends StatelessWidget {
   const EnterEndSeasonPage({super.key});
 

--- a/packages/app/lib/ui/page/enter_game_stats_page.dart
+++ b/packages/app/lib/ui/page/enter_game_stats_page.dart
@@ -1,7 +1,9 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 
 import 'play_top_page.dart';
 
+@RoutePage()
 class EnterGameStatsPage extends StatelessWidget {
   const EnterGameStatsPage({super.key});
 

--- a/packages/app/lib/ui/page/enter_profile_page.dart
+++ b/packages/app/lib/ui/page/enter_profile_page.dart
@@ -1,20 +1,9 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 
 import 'play_top_page.dart';
 
-// ### 入力
-
-// - 人物情報
-//     - 名前、生年月日、身長、体重、出身
-// - 野球情報
-//     - ポジション、利き腕、打席、経歴、入団経緯、背番号、契約金、年俸
-// - シーズン情報
-//     - チーム名、国、試合数、開始年
-// - 能力
-//     - コンタクト、パワー、ビジョン、スピード、肩、守備
-// - その他
-//     - メモ
-
+@RoutePage()
 class EnterProfilePage extends StatelessWidget {
   const EnterProfilePage({super.key});
 

--- a/packages/app/lib/ui/page/play_top_page.dart
+++ b/packages/app/lib/ui/page/play_top_page.dart
@@ -1,8 +1,9 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 
-import 'enter_end_season_page.dart';
-import 'enter_game_stats_page.dart';
+import '../../core/router/app_router.dart';
 
+@RoutePage()
 class PlayTopPage extends StatelessWidget {
   const PlayTopPage({super.key});
 
@@ -16,31 +17,21 @@ class PlayTopPage extends StatelessWidget {
             const Text('PlayTopPage'),
             ElevatedButton(
               onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute<void>(
-                    builder: (context) => const EnterGameStatsPage(),
-                  ),
-                );
+                context.pushRoute(const EnterGameStatsRoute());
               },
               child: const Text('試合を始める'),
             ),
             const SizedBox(height: 20),
             ElevatedButton(
               onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute<void>(
-                    builder: (context) => const EnterEndSeasonPage(),
-                  ),
-                );
+                context.pushRoute(const EnterEndSeasonRoute());
               },
               child: const Text('シーズンを終了する'),
             ),
             const SizedBox(height: 20),
             ElevatedButton(
               onPressed: () {
-                Navigator.popUntil(context, ModalRoute.withName('/'));
+                context.router.popUntilRoot();
               },
               child: const Text('戻る'),
             ),

--- a/packages/app/lib/ui/page/top_page.dart
+++ b/packages/app/lib/ui/page/top_page.dart
@@ -1,7 +1,9 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 
-import 'enter_profile_page.dart';
+import '../../core/router/app_router.dart';
 
+@RoutePage()
 class TopPage extends StatelessWidget {
   const TopPage({super.key});
 
@@ -15,12 +17,7 @@ class TopPage extends StatelessWidget {
             const Text('TopPage'),
             ElevatedButton(
               onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute<void>(
-                    builder: (context) => const EnterProfilePage(),
-                  ),
-                );
+                context.pushRoute(const PlayTopRoute());
               },
               child: const Text('プレイする'),
             ),

--- a/packages/app/pubspec.yaml
+++ b/packages/app/pubspec.yaml
@@ -16,7 +16,11 @@ dependencies:
   common:
     path: ../common
 
+  # Navigation.
+  auto_route: ^8.2.0
+
   # Code generation.
+  auto_route_generator: ^8.0.0
   riverpod_annotation: ^2.2.0
 
   # State management.

--- a/packages/app/pubspec.yaml
+++ b/packages/app/pubspec.yaml
@@ -24,12 +24,14 @@ dependencies:
 
   # Static analysis.
   pedantic_mono: ^1.27.0
+  riverpod_lint: ^2.3.7
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
   # Static analysis.
+  custom_lint: ^0.6.4
   flutter_lints: ^3.0.0
 
   # Code generation.

--- a/packages/common/pubspec.yaml
+++ b/packages/common/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   flutter_riverpod: ^2.4.3
 
   # Static analysis.
+  custom_lint: ^0.6.4
   pedantic_mono: ^1.27.0
   riverpod_lint: ^2.3.7
 

--- a/packages/model/pubspec.yaml
+++ b/packages/model/pubspec.yaml
@@ -18,7 +18,9 @@ dependencies:
   flutter_riverpod: ^2.4.3
 
   # Static analysis.
+  custom_lint: ^0.6.4
   pedantic_mono: ^1.27.0
+  riverpod_lint: ^2.3.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 対応する Issue

<!-- 該当の Issue を Close したくない場合は、 `Closes` の文言を削除する。 -->
Closes #14 

## リンク

<!-- タスク管理/整理用の Notion ページや参考にしたサイト等があれば記載する。 -->

## やったこと

- auto_route パッケージを導入
- 画面遷移のコードを修正
- riverpod_lint 関連の設定が漏れていたため対応

## やらなかったこと

- riverpod_lint でできるようになるはずの `Convert to ConsumerWidget` ができない事象の対応

## ユーザーへの影響

<!-- ユーザーから見て、できるようになったことやできなくなったこと等を記載する。 -->

## 動作確認

### 確認した環境

- Pixel 6a (実機) / Android 15系

### 確認したこと
<!-- スクショや動画を貼っても良い。 -->

- 画面遷移が正常にできること

### 確認しなかった（できなかった）こと

- 

## その他
